### PR TITLE
add SpringDoc OpenAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,44 @@
+=====================================================
 Spring initializr
 1. Project: Maven
 2. Language: Java
 3. Spring Boot Version: Latest stable
 4. Dependencies:
--> Spring Web (For REST API)
--> Spring Boot DevTools (For hot reload)
--> Spring Data JPA (For database)
--> MySQL Driver (For database connection)
--> Spring Security (For authentication)
--> JWT (For token-based authentication)
 
-Flower Columns:
-id (Integer, Primary Key) – Unique identifier for each flower. (Already included)
-name (String) – Common name of the flower. (Already included)
-type (String) – Category or classification of the flower (e.g., Rose, Tulip, Orchid). (Already included)
-description (String) – A brief description of the flower. (Already included)
-scientific_name (String) – Botanical or Latin name of the flower.
-color (String) – Primary color of the flower.
-bloom_season (String) – The season when the flower blooms (e.g., Spring, Summer).
-native_region (String) – Where the flower originates or is commonly found.
-sunlight_requirement (String) – Light conditions required (e.g., Full Sun, Partial Shade).
-water_requirement (String) – Frequency of watering (e.g., Low, Medium, High).
-price (Decimal/Double) – Cost of the flower (if applicable).
-stock_quantity (Integer) – Quantity available in stock (useful if it's for sales).
-added_date (Timestamp) – When the flower record was added to the system.
-updated_date (Timestamp) – When the flower record was last updated.
-image_url - flower image
+✅ Spring Boot Starters
+spring-boot-starter-data-jpa
+spring-boot-starter-web
+spring-boot-starter-security
+spring-boot-starter-test
+spring-boot-starter-validation
+spring-boot-devtools
 
+✅ Database Drivers
+mysql-connector-j
+postgresql
 
+✅ JWT (io.jsonwebtoken)
+jjwt-api (0.12.3)
+jjwt-impl (0.12.3)
+jjwt-jackson (0.12.3)
+jjwt-api (0.11.5)
+jjwt-impl (0.11.5)
+jjwt-jackson (0.11.5)
+
+✅ Lombok
+lombok (1.18.20) — listed twice
+
+✅ Swagger / OpenAPI
+springdoc-openapi-starter-webmvc-ui (2.1.0)
 =====================================================
 to run Java terminal: mvn spring-boot:run
+to build Java terminal: mvn clean package
+=====================================================
+Swagger RestApi:
+Local > http://localhost:70/swagger-ui/index.html
+
+To use Swagger:
+1. Go to link
+2. login 
+3. Add auth token w/out bearer at the front 
 =====================================================

--- a/pom.xml
+++ b/pom.xml
@@ -112,18 +112,18 @@
 			<scope>runtime</scope>
 		</dependency>
 
-
-		<!-- Swagger Dependencies -->
-		<!-- <dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger2</artifactId>
-			<version>2.9.2</version>
-		</dependency>
+		<!-- swagger -->
 		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger-ui</artifactId>
-			<version>2.9.2</version>
-		</dependency> -->
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.1.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
 	</dependencies>
 	
 	<build>

--- a/src/main/java/com/example/Drive/api/java/config/OpenApiConfig.java
+++ b/src/main/java/com/example/Drive/api/java/config/OpenApiConfig.java
@@ -1,0 +1,31 @@
+package com.example.Drive.api.java.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+            .info(new Info()
+                .title("Drive API")
+                .version("v1")
+                .description("API documentation for Drive app"))
+            .addSecurityItem(new SecurityRequirement().addList(securitySchemeName))
+            .components(new io.swagger.v3.oas.models.Components()
+                .addSecuritySchemes(securitySchemeName,
+                    new SecurityScheme()
+                        .name(securitySchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")));
+    }
+}

--- a/src/main/java/com/example/Drive/api/java/config/SecurityConfig.java
+++ b/src/main/java/com/example/Drive/api/java/config/SecurityConfig.java
@@ -20,8 +20,16 @@ public class SecurityConfig {
         http
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/v1/signup", "/api/v1/login").permitAll()
-                .anyRequest().authenticated()
+            .requestMatchers(
+                "/api/v1/signup", 
+                "/api/v1/login",
+                "/swagger-ui/**",
+                "/swagger-ui.html",
+                "/v3/api-docs/**",
+                "/swagger-resources/**",
+                "/webjars/**",
+                "/favicon.ico"
+            ).permitAll().anyRequest().authenticated()
             )
             .addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/example/Drive/api/java/filter/JwtRequestFilter.java
+++ b/src/main/java/com/example/Drive/api/java/filter/JwtRequestFilter.java
@@ -28,7 +28,14 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        return path.equals("/api/v1/login") || path.equals("/api/v1/signup");
+        return path.equals("/api/v1/login") || 
+           path.equals("/api/v1/signup") ||
+           path.startsWith("/swagger-ui/") || 
+           path.startsWith("/v3/api-docs") ||
+           path.equals("/swagger-ui.html") ||
+           path.startsWith("/swagger-resources") ||
+           path.startsWith("/webjars/") ||
+           path.equals("/favicon.ico");
     }
     
     @Override


### PR DESCRIPTION
**Summary**
This PR integrates Swagger (OpenAPI 3) documentation into the Drive API project using springdoc-openapi. It provides a user-friendly UI for exploring and testing API endpoints. The configuration also ensures compatibility with JWT-based security.

**Changes Made**
1. Added Dependency: Included springdoc-openapi-starter-webmvc-ui (version 2.1.0) to support Swagger UI with OpenAPI 3.
2. Removed Old Swagger UI: Deprecated the use of springfox-swagger-ui (version 2.9.2) which is no longer maintained and not compatible with Spring Boot 3.
3. Configured OpenAPI:
  - Created OpenApiConfig to define API metadata and JWT bearer authentication scheme.
4. Updated Security Configuration:
  - Allowed public access to Swagger-related endpoints (/swagger-ui/**, /v3/api-docs/**, etc.).
  - Adjusted the shouldNotFilter method in the JWT filter to bypass security checks for Swagger routes.

**Notes / Suggestions**
1. Ensure that springdoc-openapi is the only Swagger tool used moving forward to avoid conflicts.
2. This setup enables easier collaboration and testing by frontend teams or third-party developers through the Swagger UI.
3. You may consider enabling Swagger only in non-production environments for security reasons.