### PR TITLE
upload image using binary base64

### DIFF
--- a/src/main/java/com/example/Drive/api/java/api/FlowerController.java
+++ b/src/main/java/com/example/Drive/api/java/api/FlowerController.java
@@ -1,8 +1,10 @@
 package com.example.Drive.api.java.api;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.example.Drive.api.java.model.Flower;
 import com.example.Drive.api.java.service.FlowerService;
@@ -51,6 +53,21 @@ public class FlowerController {
         } else {
             // Handle the case where id is not found
             return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping(value = "/upload/image/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<String> uploadImage(@PathVariable("id") String id,
+                                            @RequestParam("file") MultipartFile file) {
+        try {
+            boolean uploaded = flowerService.uploadImage(id, file);
+            if (uploaded) {
+                return ResponseEntity.ok("Image uploaded successfully.");
+            } else {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body("Flower not found.");
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Image upload failed.");
         }
     }
 }

--- a/src/main/java/com/example/Drive/api/java/model/Flower.java
+++ b/src/main/java/com/example/Drive/api/java/model/Flower.java
@@ -20,8 +20,9 @@ public class Flower {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "image_url")
-    private String imageUrl;
+    @Lob
+    @Column(name = "image_data")
+    private byte[] imageData;
 
     @Column(name = "type")
     private String type;

--- a/src/main/java/com/example/Drive/api/java/service/FlowerService.java
+++ b/src/main/java/com/example/Drive/api/java/service/FlowerService.java
@@ -4,7 +4,9 @@ import com.example.Drive.api.java.repository.FlowerRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,7 +36,7 @@ public class FlowerService {
         newFlower.setName(flowerBody.getName());
         newFlower.setDescription(flowerBody.getDescription());
         newFlower.setPrice(flowerBody.getPrice());
-        newFlower.setImageUrl(flowerBody.getImageUrl());
+        newFlower.setImageData(flowerBody.getImageData());
         newFlower.setType(flowerBody.getType());
         newFlower.setScientificName(flowerBody.getScientificName());
         newFlower.setColor(flowerBody.getColor());
@@ -75,7 +77,7 @@ public class FlowerService {
         existingFlower.setName(flowerUpdBody.getName());
         existingFlower.setDescription(flowerUpdBody.getDescription());
         existingFlower.setPrice(flowerUpdBody.getPrice());
-        existingFlower.setImageUrl(flowerUpdBody.getImageUrl());
+        existingFlower.setImageData(flowerUpdBody.getImageData());
         existingFlower.setType(flowerUpdBody.getType());
         existingFlower.setScientificName(flowerUpdBody.getScientificName());
         existingFlower.setColor(flowerUpdBody.getColor());
@@ -93,4 +95,22 @@ public class FlowerService {
 
         return optionalFlower;
     }
+
+    public boolean uploadImage(String id, MultipartFile file) {
+    Optional<Flower> optionalFlower = flowerRepository.findById(id);
+        if (optionalFlower.isPresent()) {
+            Flower flower = optionalFlower.get();
+            System.out.println("SERVICE: upload image = " +flower);
+            try {
+                flower.setImageData(file.getBytes());
+                flowerRepository.save(flower);
+                return true;
+            } catch (IOException e) {
+                e.printStackTrace();
+                throw new RuntimeException("Failed to read image file");
+            }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
**Summary**
This pull request introduces a new feature that enables image uploads for flower entries in the system. A new endpoint allows users to upload images which are then stored directly in the database as binary data.

**Changes**
1. Controller (FlowerController)
    a) Added a new POST endpoint: POST /upload/image/{id}
        - Accepts a multipart file and links it to the flower entity by ID.
        - Returns appropriate HTTP responses based on upload success, failure, or entity not found.

    b) Model (Flower)
        - Added new field: imageData (byte[]) annotated with @Lob and @Column(name = "image_data") to store image content in 
          the database.
2. Service (FlowerService)
      a) Replaced imageUrl usage with imageData for flower creation and updates.
      b) Implemented uploadImage(String id, MultipartFile file) method:
          - Finds flower by ID, reads image bytes from the file, saves it to the database.

**Notes**
- Potential Improvements:
- Add file size and type validations to ensure only valid image formats are accepted.
- Consider abstracting image storage to a file system or cloud storage (e.g., S3) for better scalability.
- Implement image retrieval endpoint to serve stored image data as base64 or media response.